### PR TITLE
get more data from crawler, simplify

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -45,31 +45,6 @@
       "console": "internalConsole"
     },
     {
-      "name": "Dashboard",
-      "type": "node",
-      "request": "launch",
-      "program": "${workspaceRoot}/bin/www",
-      "stopOnEntry": false,
-      "args": [],
-      "cwd": "${workspaceRoot}",
-      "preLaunchTask": null,
-      "runtimeExecutable": null,
-      "runtimeArgs": [
-        "--nolazy"
-      ],
-      "env": {
-        "NODE_ENV": "localhost",
-        "CONFIGURATION_ENVIRONMENT": "localhost",
-        "PORT": "4000",
-        "DEBUG": "appinsights",
-        "CRAWLER_NAME": "jmcrawler",
-        "CRAWLER_QUEUE_PREFIX": "jmcrawler"
-      },
-      "console": "internalConsole",
-      "sourceMaps": false,
-      "outFiles": []
-    },
-    {
       "name": "Docker Dashboard",
       "type": "node",
       "request": "launch",
@@ -85,10 +60,6 @@
       "env": {
         "NODE_ENV": "localhost",
         "CONFIGURATION_ENVIRONMENT": "localhost",
-        "PORT": "4000",
-        "DEBUG": "appinsights",
-        "CRAWLER_NAME": "crawlerdocker",
-        "CRAWLER_QUEUE_PREFIX": "crawlerdocker",
         "CRAWLER_REDIS_TLS": "",
         "CRAWLER_REDIS_URL": "localhost",
         "CRAWLER_REDIS_PORT": "6379"
@@ -112,59 +83,25 @@
       ],
       "env": {
         "NODE_ENV": "localhost",
-        "CONFIGURATION_ENVIRONMENT": "localhost",
-        "PORT": "4000",
-        "DEBUG": "appinsights",
-        "CRAWLER_NAME": "crawlerdev",
-        "CRAWLER_QUEUE_PREFIX": "crawlerdev"
+        "CONFIGURATION_ENVIRONMENT": "localhost"
       },
       "console": "internalConsole",
       "sourceMaps": false,
       "outFiles": []
     },
     {
-      "name": "Debug",
+      "name": "Local Dashboard",
       "type": "node",
       "request": "launch",
       "program": "${workspaceRoot}/bin/www",
-      "stopOnEntry": false,
       "args": [],
       "cwd": "${workspaceRoot}",
-      "preLaunchTask": null,
-      "runtimeExecutable": null,
-      "runtimeArgs": [
-        "--nolazy"
-      ],
       "env": {
         "NODE_ENV": "localhost",
         "CONFIGURATION_ENVIRONMENT": "localhost",
-        "PORT": "4000",
-        "DEBUG": "*"
-      },
-      "console": "internalConsole",
-      "sourceMaps": false,
-      "outFiles": []
-    },
-    {
-      "name": "Local",
-      "type": "node",
-      "request": "launch",
-      "program": "${workspaceRoot}/bin/www",
-      "stopOnEntry": false,
-      "args": [],
-      "cwd": "${workspaceRoot}",
-      "preLaunchTask": null,
-      "runtimeExecutable": null,
-      "runtimeArgs": [
-        "--nolazy"
-      ],
-      "env": {
-        "CONFIGURATION_ENVIRONMENT": "localhost",
         "DEBUG": "appinsights"
       },
-      "console": "internalConsole",
-      "sourceMaps": false,
-      "outFiles": []
+      "console": "internalConsole"
     }
   ]
 }

--- a/config/dashboard.js
+++ b/config/dashboard.js
@@ -7,7 +7,6 @@ module.exports = function (configApi) {
   const environmentProvider = configApi.environment;
   return {
     crawler: {
-      name: environmentProvider.get('CRAWLER_NAME') || 'crawler',
       url: environmentProvider.get('CRAWLER_SERVICE_URL') || 'http://localhost:3000',
       apiToken: environmentProvider.get('CRAWLER_SERVICE_AUTH_TOKEN') || 'secret'
     },

--- a/dashboard/business/messageRates.js
+++ b/dashboard/business/messageRates.js
@@ -16,7 +16,6 @@ class MessageRates {
     const queuingOptions = config.dashboard.queuing;
     this.queueNames = queuingOptions.messageRatesQueueNames;
     this.operations = queuingOptions.metricsOperationNames;
-    this.crawlerName = config.dashboard.crawler.name;
     this.metricsClient = new RedisMetricsClient(redisClient);
   }
 
@@ -41,7 +40,7 @@ class MessageRates {
         });
       }
     });
-    const metricName = `${this.crawlerName}:github:fetch`;
+    const metricName = `${this.infoPoller.crawlerName}:github:fetch`;
     const displayedMetricName = 'github:fetch';
     promises.push(this.metricsClient.getMetric(metricName, displayedMetricName, startTime, now));
     Q.all(promises).then(results => {

--- a/dashboard/business/queueInfoPoller.js
+++ b/dashboard/business/queueInfoPoller.js
@@ -12,6 +12,7 @@ class QueueInfoPoller {
       data: {}
     };
     this.infos = {};
+    this.crawlerName = null;
   }
 
   initialize(config) {

--- a/dashboard/routes/index.js
+++ b/dashboard/routes/index.js
@@ -45,6 +45,8 @@ router.get('/', (request, response) => {
 router.get('/config', wrap(function* (request, response) {
   request.insights.trackEvent('crawlerConfigGetStart');
   const config = yield crawlerClient.getConfiguration();
+  config.crawler.url = crawlerClient.url;
+  queueInfoPoller.crawlerName = config.crawler.name;
   response.json(config);
   request.insights.trackEvent('crawlerConfigGetComplete');
 }));

--- a/env/env-template.json
+++ b/env/env-template.json
@@ -4,14 +4,14 @@
       "CONFIGURATION_ENVIRONMENT": "localhost",
       "DEBUG_ALLOW_HTTP": true,
       "CRAWLER_INSIGHTS_KEY": "",
-      "CRAWLER_NAME": "",
       "CRAWLER_SERVICE_URL": "",
-      "CRAWLER_QUEUE_PREFIX": "",
+
       "CRAWLER_REDIS_ACCESS_KEY": "",
       "CRAWLER_REDIS_PORT": "",
       "CRAWLER_REDIS_PREFIX": "local:crawldash",
       "CRAWLER_REDIS_TLS": "true",
       "CRAWLER_REDIS_URL": "",
+
       "AAD_CLIENT_SECRET": "",
       "AAD_CLIENT_ID": "",
       "AAD_TENANT_ID": "",

--- a/public/dashboard.html
+++ b/public/dashboard.html
@@ -12,6 +12,7 @@
   <body>
     <div class="container text-center">
       <h1>Crawler Dashboard</h1>
+      <h3 id="crawlerUrl"></h3>
     </div>
     <div class="container">
       <div class="row">

--- a/public/js/app/dashboard.js
+++ b/public/js/app/dashboard.js
@@ -198,6 +198,7 @@ var updateConfigsAlert = $('#updateConfigsAlert');
 var initialUpdateConfigString = `[\n   { "op": "replace", "path": "/crawler/count", "value": 0 }\n]`;
 updateConfigs.val(initialUpdateConfigString);
 
+var crawlerUrl = $('#crawlerUrl');
 var currentConfigs = $('#currentConfigs');
 var refreshConfigsBtn = $('#refreshConfigsBtn');
 var currentConfigsAlert = $('#currentConfigsAlert');
@@ -259,6 +260,7 @@ $('#deleteRequestsBtn').click(function () {
 function retrieveCrawlerConfiguration() {
   $.get('/config', function (data, status, xhr) {
     if (status === 'success') {
+      crawlerUrl.text(data.crawler.url);
       currentConfigs.text(JSON.stringify(data, null, 2));
       displayAlert(currentConfigsAlert, false, 'Success!');
     } else {


### PR DESCRIPTION
remove more code from the dashboard.  Now we get the cralwer name, url and queue prefix from the crawler rather than from configuration.  This greatly simplifies running the dashboard.  Basically only need the crawler url and the redis info.